### PR TITLE
feat: mostrar portadas junto a los nombres de juegos

### DIFF
--- a/frontend/public/covers/akropolis.svg
+++ b/frontend/public/covers/akropolis.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420">
+  <defs>
+    <linearGradient id="akropolisGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FBD786" />
+      <stop offset="100%" stop-color="#f7797d" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="28" fill="url(#akropolisGradient)" />
+  <g opacity="0.35" fill="none" stroke="rgba(255,255,255,0.8)" stroke-width="10">
+    <polygon points="80,320 160,180 240,320" />
+    <line x1="120" y1="260" x2="200" y2="260" />
+    <line x1="100" y1="300" x2="220" y2="300" />
+  </g>
+  <text x="36" y="280" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="40" font-weight="800" fill="white">
+    AKROPOLIS
+  </text>
+  <text x="36" y="320" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="22" font-weight="600" fill="rgba(255,255,255,0.85)">
+    Construye la ciudad
+  </text>
+</svg>

--- a/frontend/public/covers/bohnanza.svg
+++ b/frontend/public/covers/bohnanza.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420">
+  <defs>
+    <linearGradient id="bohnanzaGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffafbd" />
+      <stop offset="100%" stop-color="#ffc3a0" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="28" fill="url(#bohnanzaGradient)" />
+  <g>
+    <path d="M160 140c-30 0-54 24-54 54s24 54 54 54 54-24 54-54-24-54-54-54zm0 32a22 22 0 110 44 22 22 0 010-44z" fill="rgba(0,0,0,0.25)" />
+    <rect x="148" y="80" width="24" height="60" rx="12" fill="rgba(0,0,0,0.2)" />
+  </g>
+  <text x="36" y="300" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="42" font-weight="800" fill="white">
+    BOHNANZA
+  </text>
+  <text x="36" y="340" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="22" font-weight="600" fill="rgba(255,255,255,0.85)">
+    Comerciando judías
+  </text>
+</svg>

--- a/frontend/public/covers/dune-imperium.svg
+++ b/frontend/public/covers/dune-imperium.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420">
+  <defs>
+    <linearGradient id="duneGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#654ea3" />
+      <stop offset="100%" stop-color="#eaafc8" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="28" fill="url(#duneGradient)" />
+  <g fill="rgba(0,0,0,0.25)">
+    <path d="M40 280c40-20 80-20 120 0s80 20 120 0v80H40z" />
+    <circle cx="220" cy="150" r="52" />
+    <circle cx="100" cy="120" r="28" />
+  </g>
+  <text x="36" y="300" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="42" font-weight="800" fill="white">
+    DUNE
+  </text>
+  <text x="36" y="340" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="28" font-weight="600" fill="rgba(255,255,255,0.85)">
+    Imperium
+  </text>
+</svg>

--- a/frontend/public/covers/earth.svg
+++ b/frontend/public/covers/earth.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420">
+  <defs>
+    <linearGradient id="earthGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#11998e" />
+      <stop offset="100%" stop-color="#38ef7d" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="28" fill="url(#earthGradient)" />
+  <g fill="rgba(255,255,255,0.25)">
+    <circle cx="160" cy="160" r="60" />
+    <path d="M120 200c20 30 60 30 80 0s60-30 80 0c-10 70-70 130-160 130-30 0-60-10-80-30 0-50 40-80 80-100z" />
+  </g>
+  <text x="36" y="300" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="48" font-weight="800" fill="white">
+    EARTH
+  </text>
+  <text x="36" y="340" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="24" font-weight="600" fill="rgba(255,255,255,0.85)">
+    Cultiva tu bioma
+  </text>
+</svg>

--- a/frontend/public/covers/heat-pedal-to-the-metal.svg
+++ b/frontend/public/covers/heat-pedal-to-the-metal.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420">
+  <defs>
+    <linearGradient id="heatGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FF512F" />
+      <stop offset="100%" stop-color="#F09819" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="28" fill="url(#heatGradient)" />
+  <g fill="rgba(0,0,0,0.35)">
+    <path d="M40 320h60l40-160 40 160h60l-70-240h-60z" opacity="0.3" />
+    <circle cx="260" cy="110" r="40" opacity="0.2" />
+  </g>
+  <text x="36" y="280" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="44" font-weight="800" fill="white">
+    HEAT
+  </text>
+  <text x="36" y="322" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="24" font-weight="600" fill="rgba(255,255,255,0.9)">
+    Pedal to the Metal
+  </text>
+</svg>

--- a/frontend/public/covers/kutna-hora.svg
+++ b/frontend/public/covers/kutna-hora.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420">
+  <defs>
+    <linearGradient id="kutnaGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#8360c3" />
+      <stop offset="100%" stop-color="#2ebf91" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="28" fill="url(#kutnaGradient)" />
+  <g fill="rgba(0,0,0,0.25)">
+    <path d="M60 300l40-120 40 80 40-160 40 200 40-100" stroke="rgba(255,255,255,0.5)" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    <rect x="70" y="320" width="180" height="24" rx="8" />
+  </g>
+  <text x="36" y="280" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="34" font-weight="800" fill="white">
+    KUTNÁ HORA
+  </text>
+  <text x="36" y="320" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="22" font-weight="600" fill="rgba(255,255,255,0.88)">
+    La ciudad de plata
+  </text>
+</svg>

--- a/frontend/public/covers/revive.svg
+++ b/frontend/public/covers/revive.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420">
+  <defs>
+    <linearGradient id="reviveGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#00b09b" />
+      <stop offset="100%" stop-color="#96c93d" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="28" fill="url(#reviveGradient)" />
+  <g fill="rgba(255,255,255,0.28)">
+    <path d="M160 120l60 120h-40v80h-40v-80h-40z" />
+    <circle cx="160" cy="140" r="34" />
+  </g>
+  <text x="160" y="320" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="46" font-weight="800" fill="white" text-anchor="middle">
+    REVIVE
+  </text>
+  <text x="160" y="356" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="22" font-weight="600" fill="rgba(255,255,255,0.85)" text-anchor="middle">
+    Renace la civilización
+  </text>
+</svg>

--- a/frontend/public/covers/scout.svg
+++ b/frontend/public/covers/scout.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420">
+  <defs>
+    <linearGradient id="scoutGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff9966" />
+      <stop offset="100%" stop-color="#ff5e62" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="28" fill="url(#scoutGradient)" />
+  <g fill="none" stroke="rgba(255,255,255,0.5)" stroke-width="14" stroke-linecap="round">
+    <path d="M80 160l160 160" />
+    <path d="M240 160L80 320" />
+  </g>
+  <circle cx="160" cy="220" r="48" fill="rgba(0,0,0,0.2)" />
+  <text x="160" y="320" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="46" font-weight="800" fill="white" text-anchor="middle">
+    SCOUT
+  </text>
+  <text x="160" y="356" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="22" font-weight="600" fill="rgba(255,255,255,0.85)" text-anchor="middle">
+    Trucos y combos
+  </text>
+</svg>

--- a/frontend/public/covers/sky-team.svg
+++ b/frontend/public/covers/sky-team.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420">
+  <defs>
+    <linearGradient id="skyGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1FA2FF" />
+      <stop offset="100%" stop-color="#12D8FA" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="28" fill="url(#skyGradient)" />
+  <path d="M40 180c40-40 80-40 120 0s80 40 120 0" fill="none" stroke="rgba(255,255,255,0.45)" stroke-width="20" stroke-linecap="round" />
+  <circle cx="160" cy="200" r="48" fill="rgba(255,255,255,0.25)" />
+  <path d="M120 240h80l-40-120z" fill="white" opacity="0.85" />
+  <text x="160" y="310" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="44" font-weight="800" fill="white" text-anchor="middle">
+    SKY TEAM
+  </text>
+</svg>

--- a/frontend/src/components/GameTitle.tsx
+++ b/frontend/src/components/GameTitle.tsx
@@ -1,0 +1,56 @@
+import { clsx } from 'clsx'
+import { resolveGameCover } from '../utils/gameCovers'
+import type { HTMLAttributes, ReactNode } from 'react'
+
+type GameTitleSize = 'sm' | 'md' | 'lg'
+
+const COVER_SIZES: Record<GameTitleSize, string> = {
+  sm: 'h-10 w-10',
+  md: 'h-14 w-14',
+  lg: 'h-20 w-20',
+}
+
+const TEXT_DEFAULTS: Record<GameTitleSize, string> = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+}
+
+interface GameTitleProps extends HTMLAttributes<HTMLSpanElement> {
+  name: string
+  coverUrl?: string
+  size?: GameTitleSize
+  textClassName?: string
+  coverClassName?: string
+  children?: ReactNode
+}
+
+export function GameTitle({
+  name,
+  coverUrl,
+  size = 'md',
+  className,
+  textClassName,
+  coverClassName,
+  children,
+  ...rest
+}: GameTitleProps) {
+  const resolvedCover = resolveGameCover(name, coverUrl)
+  const coverSizeClass = COVER_SIZES[size]
+  const resolvedTextClass = textClassName ?? TEXT_DEFAULTS[size]
+
+  return (
+    <span className={clsx('inline-flex items-center gap-3', className)} {...rest}>
+      <img
+        src={resolvedCover}
+        alt={`Portada de ${name}`}
+        className={clsx('flex-shrink-0 rounded-xl object-cover shadow-sm', coverSizeClass, coverClassName)}
+        loading="lazy"
+      />
+      <span className="flex flex-col gap-1">
+        <span className={clsx('font-semibold text-text-primary', resolvedTextClass)}>{name}</span>
+        {children}
+      </span>
+    </span>
+  )
+}

--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -1,4 +1,5 @@
 import { CalendarCheck, Clock, MapPin, Plus } from 'lucide-react'
+import { GameTitle } from '../components/GameTitle'
 
 const openTables = [
   {
@@ -59,10 +60,17 @@ export function Board() {
         {openTables.map((table) => (
           <article key={table.id} className="card space-y-4 p-5">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-              <div>
+              <div className="space-y-2">
                 <p className="text-xs uppercase tracking-wide text-text-secondary">Juego</p>
-                <h3 className="text-xl font-semibold text-text-primary">{table.game}</h3>
-                <p className="text-sm text-text-secondary">Anfitrión: {table.host}</p>
+                <GameTitle
+                  name={table.game}
+                  size="md"
+                  textClassName="text-xl"
+                  role="heading"
+                  aria-level={3}
+                >
+                  <p className="text-sm font-normal text-text-secondary">Anfitrión: {table.host}</p>
+                </GameTitle>
               </div>
               <div className="flex items-center gap-3">
                 <span className="rounded-full bg-primary/10 px-3 py-1 text-sm font-semibold text-primary">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { getCurrentCongressDay, formatHour } from '../utils/date'
+import { GameTitle } from '../components/GameTitle'
 
 const quickActions = [
   {
@@ -195,7 +196,13 @@ export function Home() {
             {recentPlays.map((play) => (
               <article key={play.id} className="card flex items-start justify-between gap-4 p-5">
                 <div className="space-y-2">
-                  <h3 className="text-lg font-semibold text-text-primary">{play.game}</h3>
+                  <GameTitle
+                    name={play.game}
+                    size="sm"
+                    textClassName="text-lg"
+                    role="heading"
+                    aria-level={3}
+                  />
                   <div className="flex flex-wrap gap-2 text-sm text-text-secondary">
                     {play.players.map((player) => (
                       <span key={player} className="rounded-full bg-background px-3 py-1">

--- a/frontend/src/pages/Library.tsx
+++ b/frontend/src/pages/Library.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react'
 import type { BggSearchResult } from '../utils/bgg'
 import { getBoardGameDetails, searchBoardGames } from '../utils/bgg'
+import { GameTitle } from '../components/GameTitle'
 
 interface GameEntry {
   id: number
@@ -22,6 +23,7 @@ interface GameEntry {
   language: string
   mechanics: string[]
   manual?: boolean
+  coverUrl?: string
 }
 
 const initialLibrary: GameEntry[] = [
@@ -35,6 +37,7 @@ const initialLibrary: GameEntry[] = [
     language: 'ES',
     mechanics: ['Carreras', 'Gestión de mano'],
     manual: true,
+    coverUrl: '/covers/heat-pedal-to-the-metal.svg',
   },
   {
     id: 2,
@@ -46,6 +49,7 @@ const initialLibrary: GameEntry[] = [
     language: 'EN',
     mechanics: ['Cooperativo', 'Tiradas ocultas'],
     manual: true,
+    coverUrl: '/covers/sky-team.svg',
   },
   {
     id: 3,
@@ -57,6 +61,7 @@ const initialLibrary: GameEntry[] = [
     language: 'ES',
     mechanics: ['Economía', 'Construcción'],
     manual: true,
+    coverUrl: '/covers/kutna-hora.svg',
   },
   {
     id: 4,
@@ -68,6 +73,7 @@ const initialLibrary: GameEntry[] = [
     language: 'FR',
     mechanics: ['Puzzle', 'Draft'],
     manual: true,
+    coverUrl: '/covers/akropolis.svg',
   },
 ]
 
@@ -197,6 +203,7 @@ export function Library() {
           weight: weightLabel,
           language: 'BGG',
           mechanics,
+          coverUrl: details.imageUrl ?? details.thumbnailUrl,
         }
 
         const next = [...current, entry]
@@ -330,8 +337,12 @@ export function Library() {
                     key={result.id}
                     className="flex flex-col gap-2 rounded-xl bg-background px-4 py-3 text-sm text-text-secondary md:flex-row md:items-center md:justify-between"
                   >
-                    <div>
-                      <p className="font-semibold text-text-primary">{result.name}</p>
+                    <div className="space-y-1">
+                      <GameTitle
+                        name={result.name}
+                        size="sm"
+                        textClassName="text-sm"
+                      />
                       <p className="text-xs text-text-secondary">
                         BGG #{result.id}
                         {result.yearPublished ? ` • Año ${result.yearPublished}` : ''}
@@ -367,11 +378,18 @@ export function Library() {
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         {filtered.map((game) => (
           <article key={game.id} className="card flex flex-col gap-4 p-5">
-            <div className="flex items-center justify-between">
-              <div>
-                <h3 className="text-lg font-semibold text-text-primary">{game.title}</h3>
-                <p className="text-sm text-text-secondary">Propietario: {game.owner}</p>
-              </div>
+            <div className="flex items-start justify-between gap-4">
+              <GameTitle
+                name={game.title}
+                coverUrl={game.coverUrl}
+                size="lg"
+                className="items-start"
+                textClassName="text-xl"
+                role="heading"
+                aria-level={3}
+              >
+                <p className="text-sm font-normal text-text-secondary">Propietario: {game.owner}</p>
+              </GameTitle>
               {game.manual ? (
                 <span className="rounded-full bg-secondary/10 px-3 py-1 text-xs font-semibold text-secondary">Manual</span>
               ) : (

--- a/frontend/src/pages/Organization.tsx
+++ b/frontend/src/pages/Organization.tsx
@@ -18,6 +18,7 @@ import {
   Users,
 } from 'lucide-react'
 import { getCurrentCongressDay } from '../utils/date'
+import { GameTitle } from '../components/GameTitle'
 
 type PanelTab = 'attendees' | 'whitelist' | 'duplicates' | 'exports'
 
@@ -457,12 +458,18 @@ export function Organization() {
               return (
                 <article key={duplicate.id} className="rounded-2xl border border-slate-200/60 bg-surface p-4">
                   <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                    <div>
-                      <h3 className="text-lg font-semibold text-text-primary">{duplicate.game}</h3>
-                      <p className="text-sm text-text-secondary">
+                    <GameTitle
+                      name={duplicate.game}
+                      size="sm"
+                      textClassName="text-lg"
+                      className="items-start"
+                      role="heading"
+                      aria-level={3}
+                    >
+                      <p className="text-sm font-normal text-text-secondary">
                         {duplicate.players.join(', ')} · Coincidencia {duplicate.similarity}%
                       </p>
-                    </div>
+                    </GameTitle>
                     <div className="flex flex-wrap gap-2">
                       <span
                         className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold ${statusStyles.className}`}

--- a/frontend/src/pages/Statistics.tsx
+++ b/frontend/src/pages/Statistics.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { ArrowDownToLine, BarChart3, LineChart, Timer, Trophy, Users } from 'lucide-react'
 import { clsx } from 'clsx'
 import { getCurrentCongressDay } from '../utils/date'
+import { GameTitle } from '../components/GameTitle'
 
 type StatsTab = 'global' | 'personal'
 
@@ -283,8 +284,12 @@ export function Statistics() {
             <div className="grid gap-4 md:grid-cols-3">
               {topGames.map((game) => (
                 <div key={game.title} className="rounded-2xl bg-background px-4 py-3 text-sm text-text-secondary">
-                  <p className="text-base font-semibold text-text-primary">{game.title}</p>
-                  <p>{game.plays} partidas registradas</p>
+                  <GameTitle
+                    name={game.title}
+                    size="sm"
+                    textClassName="text-base"
+                  />
+                  <p className="mt-2">{game.plays} partidas registradas</p>
                   <p>{game.players} jugadores únicos</p>
                   <p>Tiempo acumulado: {game.time}</p>
                 </div>

--- a/frontend/src/utils/bgg.ts
+++ b/frontend/src/utils/bgg.ts
@@ -69,6 +69,10 @@ function getAttribute(element: Element | null, attribute: string) {
   return element?.getAttribute(attribute) ?? undefined
 }
 
+function getTextContent(element: Element | null) {
+  return element?.textContent ?? undefined
+}
+
 export interface BggSearchResult {
   id: number
   name: string
@@ -86,6 +90,8 @@ export interface BggGameDetails {
   playingTime?: number
   averageWeight?: number
   mechanics: string[]
+  thumbnailUrl?: string
+  imageUrl?: string
 }
 
 export async function searchBoardGames(query: string): Promise<BggSearchResult[]> {
@@ -149,5 +155,7 @@ export async function getBoardGameDetails(id: number): Promise<BggGameDetails> {
     playingTime: playingTime || undefined,
     averageWeight: averageWeight || undefined,
     mechanics,
+    thumbnailUrl: getTextContent(item.querySelector('thumbnail')) ?? undefined,
+    imageUrl: getTextContent(item.querySelector('image')) ?? undefined,
   }
 }

--- a/frontend/src/utils/gameCovers.ts
+++ b/frontend/src/utils/gameCovers.ts
@@ -1,0 +1,99 @@
+const COVER_MAP: Record<string, string> = {
+  'heat: pedal to the metal': '/covers/heat-pedal-to-the-metal.svg',
+  'sky team': '/covers/sky-team.svg',
+  'kutná hora': '/covers/kutna-hora.svg',
+  'kutna hora': '/covers/kutna-hora.svg',
+  'akropolis': '/covers/akropolis.svg',
+  revive: '/covers/revive.svg',
+  scout: '/covers/scout.svg',
+  earth: '/covers/earth.svg',
+  bohnanza: '/covers/bohnanza.svg',
+  'dune: imperium': '/covers/dune-imperium.svg',
+}
+
+function normalize(name: string) {
+  return name.trim().toLowerCase()
+}
+
+export function getGameCover(name: string) {
+  return COVER_MAP[normalize(name)]
+}
+
+function escapeXml(value: string) {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function hashName(value: string) {
+  let hash = 0
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index)
+    hash |= 0
+  }
+  return Math.abs(hash)
+}
+
+function getGradientColors(hash: number) {
+  const hue = hash % 360
+  const secondaryHue = (hue + 35) % 360
+  return {
+    start: `hsl(${hue}, 70%, 48%)`,
+    end: `hsl(${secondaryHue}, 70%, 58%)`,
+  }
+}
+
+function getLines(name: string) {
+  const words = name.split(/\s+/).filter(Boolean)
+
+  if (words.length <= 2) {
+    return [escapeXml(name), '']
+  }
+
+  const firstLine: string[] = []
+  const secondLine: string[] = []
+
+  for (const word of words) {
+    if ((firstLine.join(' ') + ' ' + word).trim().length <= 16 || firstLine.length === 0) {
+      firstLine.push(word)
+    } else {
+      secondLine.push(word)
+    }
+  }
+
+  return [escapeXml(firstLine.join(' ')), escapeXml(secondLine.join(' '))]
+}
+
+export function generatePlaceholderCover(name: string) {
+  const trimmed = name.trim() || 'Juego'
+  const hash = hashName(trimmed)
+  const gradientId = `grad-${hash}`
+  const { start, end } = getGradientColors(hash)
+  const initials = trimmed
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 3)
+    .map((word) => word[0]?.toUpperCase() ?? '')
+    .join('')
+    .slice(0, 3)
+  const [line1, line2] = getLines(trimmed)
+
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420" width="320" height="420" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="${gradientId}" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="${start}" />
+      <stop offset="100%" stop-color="${end}" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="28" fill="url(#${gradientId})" />
+  <circle cx="72" cy="70" r="36" fill="rgba(0,0,0,0.25)" />
+  <text x="72" y="80" text-anchor="middle" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="38" font-weight="700" fill="white">${initials}</text>
+  <text x="32" y="270" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="36" font-weight="700" fill="white">${line1}</text>
+  ${line2 ? `<text x="32" y="318" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="28" font-weight="600" fill="rgba(255,255,255,0.85)">${line2}</text>` : ''}
+</svg>`
+
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
+}
+
+export function resolveGameCover(name: string, explicit?: string) {
+  return explicit ?? getGameCover(name) ?? generatePlaceholderCover(name)
+}


### PR DESCRIPTION
## Summary
- crear el componente `GameTitle` y utilidades para resolver la portada de cada juego, incluyendo recursos gráficos en `public/covers`
- actualizar la ludoteca para que muestre las portadas tanto en los juegos locales como en los importados desde BGG
- aplicar la nueva presentación en secciones de actividad reciente, tablón, estadísticas y alertas de duplicados

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d423faeef4832c9bd59d1dbd35ba03