### PR TITLE
Integrate Firebase auth onboarding flow

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "clsx": "^2.1.1",
+        "firebase": "^12.3.0",
         "lucide-react": "^0.544.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -922,6 +923,645 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.3.0.tgz",
+      "integrity": "sha512-rVZgf4FszXPSFVIeWLE8ruLU2JDmPXw4XgghcC0x/lK9veGJIyu+DvyumjreVhW/RwD3E5cNPWxQunzylhf/6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.18.tgz",
+      "integrity": "sha512-iN7IgLvM06iFk8BeFoWqvVpRFW3Z70f+Qe2PfCJ7vPIgLPjHXDE774DhCT5Y2/ZU/ZbXPDPD60x/XPWEoZLNdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.24.tgz",
+      "integrity": "sha512-jE+kJnPG86XSqGQGhXXYt1tpTbCTED8OQJ/PQ90SEw14CuxRxx/H+lFbWA1rlFtFSsTCptAJtgyRBwr/f00vsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.18",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.3.tgz",
+      "integrity": "sha512-by1leTfZkwGycPKRWpc+p5/IhpnOj8zaScVi4RRm9fMoFYS3IE87Wzx1Yf/ruVYowXOEuLqYY3VmJw5tU3+0Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.0.tgz",
+      "integrity": "sha512-XAvALQayUMBJo58U/rxW02IhsesaxxfWVmVkauZvGEz3vOAjMEQnzFlyblqkc2iAaO82uJ2ZVyZv9XzPfxjJ6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.0.tgz",
+      "integrity": "sha512-UfK2Q8RJNjYM/8MFORltZRG9lJj11k0nW84rrffiKvcJxLf1jf6IEjCIkCamykHE73C6BwqhVfhIBs69GXQV0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.3.tgz",
+      "integrity": "sha512-rRK9YOvgsAU/+edjgubL1q1FyCMjBZZs+fAWtD36tklawkh6WZV07sNLVSceuni+a21oby6xoad+3R8dfztOrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.11.0.tgz",
+      "integrity": "sha512-5j7+ua93X+IRcJ1oMDTClTo85l7Xe40WSkoJ+shzPrX7OISlVWLdE1mKC57PSD+/LfAbdhJmvKixINBw2ESK6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.0.tgz",
+      "integrity": "sha512-J0lGSxXlG/lYVi45wbpPhcWiWUMXevY4fvLZsN1GHh+po7TZVng+figdHBVhFheaiipU8HZyc7ljw1jNojM2nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
+      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.11.tgz",
+      "integrity": "sha512-G258eLzAD6im9Bsw+Qm1Z+P4x0PGNQ45yeUuuqe5M9B1rn0RJvvsQCRHXgE52Z+n9+WX1OJd/crcuunvOGc7Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
+      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-types": "1.0.16",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
+      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.13.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.9.2.tgz",
+      "integrity": "sha512-iuA5+nVr/IV/Thm0Luoqf2mERUvK9g791FZpUJV1ZGXO6RL2/i/WFJUj5ZTVXy5pRjpWYO+ZzPcReNrlilmztA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "@firebase/webchannel-wrapper": "1.0.5",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.2.tgz",
+      "integrity": "sha512-cy7ov6SpFBx+PHwFdOOjbI7kH00uNKmIFurAn560WiPCZXy9EMnil1SOG7VF4hHZKdenC+AHtL4r3fNpirpm0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/firestore": "4.9.2",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.1.tgz",
+      "integrity": "sha512-sUeWSb0rw5T+6wuV2o9XNmh9yHxjFI9zVGFnjFi+n7drTEWpl7ZTz1nROgGrSu472r+LAaj+2YaSicD4R8wfbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.1.tgz",
+      "integrity": "sha512-AxxUBXKuPrWaVNQ8o1cG1GaCAtXT8a0eaTDfqgS5VsRYLAR0ALcfqDLwo/QyijZj1w8Qf8n3Qrfy/+Im245hOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/functions": "0.13.1",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.19.tgz",
+      "integrity": "sha512-nGDmiwKLI1lerhwfwSHvMR9RZuIH5/8E3kgUWnVRqqL7kGVSktjLTWEMva7oh5yxQ3zXfIlIwJwMcaM5bK5j8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.19.tgz",
+      "integrity": "sha512-khfzIY3EI5LePePo7vT19/VEIH1E3iYsHknI/6ek9T8QCozAZshWT9CjlwOzZrKvTHMeNcbpo/VSOSIWDSjWdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.23.tgz",
+      "integrity": "sha512-cfuzv47XxqW4HH/OcR5rM+AlQd1xL/VhuaeW/wzMW1LFrsFcTn0GND/hak1vkQc2th8UisBcrkVcQAnOnKwYxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.23.tgz",
+      "integrity": "sha512-SN857v/kBUvlQ9X/UjAqBoQ2FEaL1ZozpnmL1ByTe57iXkmnVVFm9KqAsTfmf+OEwWI4kJJe9NObtN/w22lUgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.9.tgz",
+      "integrity": "sha512-UzybENl1EdM2I1sjYm74xGt/0JzRnU/0VmfMAKo2LSpHJzaj77FCLZXmYQ4oOuE+Pxtt8Wy2BVJEENiZkaZAzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.22.tgz",
+      "integrity": "sha512-xLKxaSAl/FVi10wDX/CHIYEUP13jXUjinL+UaNXT9ByIvxII5Ne5150mx6IgM8G6Q3V+sPiw9C8/kygkyHUVxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.9",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.7.0.tgz",
+      "integrity": "sha512-dX95X6WlW7QlgNd7aaGdjAIZUiQkgWgNS+aKNu4Wv92H1T8Ue/NDUjZHd9xb8fHxLXIHNZeco9/qbZzr500MjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.20.tgz",
+      "integrity": "sha512-P/ULS9vU35EL9maG7xp66uljkZgcPMQOxLj3Zx2F289baTKSInE6+YIkgHEi1TwHoddC/AFePXPpshPlEFkbgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.7.0",
+        "@firebase/remote-config-types": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
+      "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.0.tgz",
+      "integrity": "sha512-xWWbb15o6/pWEw8H01UQ1dC5U3rf8QTAzOChYyCpafV6Xki7KVp3Yaw2nSklUwHEziSWE9KoZJS7iYeyqWnYFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.0.tgz",
+      "integrity": "sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
+      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.5.tgz",
+      "integrity": "sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1090,6 +1730,70 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.35",
@@ -1465,6 +2169,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
@@ -1834,7 +2547,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2103,6 +2815,78 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2116,7 +2900,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2129,7 +2912,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -2306,7 +3088,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2564,6 +3345,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2605,6 +3398,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.3.0.tgz",
+      "integrity": "sha512-/JVja0IDO8zPETGv4TvvBwo7RwcQFz+RQ3JBETNtUSeqsDdI9G7fhRTkCy1sPKnLzW0xpm/kL8GOj6ncndTT3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.3.0",
+        "@firebase/analytics": "0.10.18",
+        "@firebase/analytics-compat": "0.2.24",
+        "@firebase/app": "0.14.3",
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-compat": "0.4.0",
+        "@firebase/app-compat": "0.5.3",
+        "@firebase/app-types": "0.9.3",
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-compat": "0.6.0",
+        "@firebase/data-connect": "0.3.11",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-compat": "2.1.0",
+        "@firebase/firestore": "4.9.2",
+        "@firebase/firestore-compat": "0.4.2",
+        "@firebase/functions": "0.13.1",
+        "@firebase/functions-compat": "0.4.1",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-compat": "0.2.19",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/messaging-compat": "0.2.23",
+        "@firebase/performance": "0.7.9",
+        "@firebase/performance-compat": "0.2.22",
+        "@firebase/remote-config": "0.7.0",
+        "@firebase/remote-config-compat": "0.2.20",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-compat": "0.4.0",
+        "@firebase/util": "1.13.0"
       }
     },
     "node_modules/flat-cache": {
@@ -2692,6 +3521,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob": {
@@ -2797,6 +3635,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2877,7 +3727,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3066,12 +3915,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3558,6 +4419,30 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3681,6 +4566,15 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -3788,6 +4682,26 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -4165,6 +5079,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4215,6 +5135,12 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -4370,6 +5296,35 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4491,6 +5446,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -4509,6 +5473,74 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "firebase": "^12.3.0",
     "lucide-react": "^0.544.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -1,0 +1,156 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { onAuthStateChanged, signOut as firebaseSignOut, type User } from 'firebase/auth'
+import { doc, onSnapshot, type DocumentData } from 'firebase/firestore'
+import { auth, db } from '../utils/firebase'
+
+type LanguageOption = 'es' | 'en'
+
+type UserPreferences = {
+  notifications?: boolean
+  darkMode?: boolean
+  availableToPlay?: boolean
+}
+
+type UserProfile = {
+  alias?: string
+  fullName?: string
+  language?: LanguageOption
+  bio?: string
+  consentAt?: Date | null
+  role?: string
+  preferences?: UserPreferences
+}
+
+type AuthorizedEntry = {
+  role?: string
+  invitedBy?: string
+  displayName?: string
+  notes?: string
+}
+
+type AuthContextValue = {
+  user: User | null
+  loading: boolean
+  profile: UserProfile | null
+  profileLoading: boolean
+  authorized: AuthorizedEntry | null
+  signOut: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [profile, setProfile] = useState<UserProfile | null>(null)
+  const [profileLoading, setProfileLoading] = useState(true)
+  const [authorized, setAuthorized] = useState<AuthorizedEntry | null>(null)
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (nextUser) => {
+      setUser(nextUser)
+      setLoading(false)
+    })
+
+    return unsubscribe
+  }, [])
+
+  useEffect(() => {
+    if (!user) {
+      setProfile(null)
+      setProfileLoading(false)
+      setAuthorized(null)
+      return
+    }
+
+    setProfileLoading(true)
+    const profileRef = doc(db, 'users', user.uid)
+    const unsubscribeProfile = onSnapshot(
+      profileRef,
+      (snapshot) => {
+        const data = snapshot.data()
+        setProfile(data ? mapProfile(data) : null)
+        setProfileLoading(false)
+      },
+      () => {
+        setProfile(null)
+        setProfileLoading(false)
+      },
+    )
+
+    const email = user.email?.toLowerCase()
+    if (!email) {
+      setAuthorized(null)
+      return () => {
+        unsubscribeProfile()
+      }
+    }
+
+    const authorizedRef = doc(db, 'authorizedEmails', email)
+    const unsubscribeAuthorized = onSnapshot(
+      authorizedRef,
+      (snapshot) => {
+        const data = snapshot.data()
+        setAuthorized(data ? mapAuthorized(data) : null)
+      },
+      () => {
+        setAuthorized(null)
+      },
+    )
+
+    return () => {
+      unsubscribeProfile()
+      unsubscribeAuthorized()
+    }
+  }, [user])
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      loading,
+      profile,
+      profileLoading,
+      authorized,
+      signOut: () => firebaseSignOut(auth),
+    }),
+    [authorized, loading, profile, profileLoading, user],
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+
+  return context
+}
+
+function mapProfile(data: DocumentData): UserProfile {
+  return {
+    alias: data.alias ?? undefined,
+    fullName: data.fullName ?? undefined,
+    language: data.language ?? 'es',
+    bio: data.bio ?? undefined,
+    consentAt: data.consentAt ? data.consentAt.toDate?.() ?? null : null,
+    role: data.role ?? undefined,
+    preferences: {
+      notifications: data.preferences?.notifications ?? false,
+      darkMode: data.preferences?.darkMode ?? false,
+      availableToPlay: data.preferences?.availableToPlay ?? false,
+    },
+  }
+}
+
+function mapAuthorized(data: DocumentData): AuthorizedEntry {
+  return {
+    role: data.role ?? undefined,
+    invitedBy: data.invitedBy ?? undefined,
+    displayName: data.displayName ?? undefined,
+    notes: data.notes ?? undefined,
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { AuthProvider } from './components/AuthProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )

--- a/frontend/src/pages/Access.tsx
+++ b/frontend/src/pages/Access.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { FormEvent, JSX } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { clsx } from 'clsx'
 import {
   ArrowLeft,
@@ -13,14 +13,12 @@ import {
   Sparkles,
   UserRound,
 } from 'lucide-react'
-
-const AUTHORIZED_EMAILS = [
-  'ulises1002048@gmail.com',
-  'patricio1002048@gmail.com',
-  'tomas1002048@gmail.com',
-  'saul1002048@gmail.com',
-  'alejandro.martin.millan@gmail.com',
-].map((email) => email.toLowerCase())
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut } from 'firebase/auth'
+import { doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore'
+import type { DocumentData } from 'firebase/firestore'
+import type { FirebaseError } from 'firebase/app'
+import { auth, db } from '../utils/firebase'
+import { useAuth } from '../components/AuthProvider'
 
 const onboardingSteps = [
   {
@@ -50,47 +48,144 @@ type LanguageOption = 'es' | 'en'
 
 type VerificationStatus = 'idle' | 'checking' | 'success' | 'error'
 
+type AuthorizedEntry = {
+  email: string
+  role?: string
+  displayName?: string
+}
+
 const SUPPORT_EMAIL = 'soporte@juegoscongreso.com'
 
 export function Access() {
+  const navigate = useNavigate()
+  const { user, profile } = useAuth()
+
   const [currentStep, setCurrentStep] = useState<StepKey>('welcome')
-  const [email, setEmail] = useState('ulises1002048@gmail.com')
-  const [password, setPassword] = useState('congreso2025')
-  const [alias, setAlias] = useState('Ulises')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [alias, setAlias] = useState('')
   const [fullName, setFullName] = useState('')
   const [language, setLanguage] = useState<LanguageOption>('es')
   const [consent, setConsent] = useState(false)
   const [showLoginErrors, setShowLoginErrors] = useState(false)
   const [verificationStatus, setVerificationStatus] = useState<VerificationStatus>('idle')
   const [verificationAttempt, setVerificationAttempt] = useState(0)
+  const [verificationError, setVerificationError] = useState<string | null>(null)
   const [profileSaved, setProfileSaved] = useState(false)
+  const [profileError, setProfileError] = useState<string | null>(null)
+  const [savingProfile, setSavingProfile] = useState(false)
+  const [authorizedEntry, setAuthorizedEntry] = useState<AuthorizedEntry | null>(null)
+  const [profilePrefilled, setProfilePrefilled] = useState(false)
 
   const activeIndex = onboardingSteps.findIndex((step) => step.key === currentStep)
   const activeStep = onboardingSteps[activeIndex]
   const progress = ((activeIndex + 1) / onboardingSteps.length) * 100
 
+  const normalizedEmail = useMemo(() => email.trim().toLowerCase(), [email])
   const isEmailValid = useMemo(() => /.+@.+\..+/.test(email), [email])
   const isPasswordValid = password.trim().length >= 8
   const canSubmitLogin = isEmailValid && isPasswordValid
   const isAliasValid = alias.trim().length >= 2
-  const canFinishProfile = isAliasValid && consent
+  const canFinishProfile = isAliasValid && consent && !savingProfile
+
+  useEffect(() => {
+    if (user?.email && currentStep === 'welcome') {
+      setEmail(user.email)
+      setCurrentStep('profile')
+    }
+  }, [currentStep, user])
 
   useEffect(() => {
     if (currentStep !== 'verification') {
       return
     }
 
-    setVerificationStatus('checking')
-    const normalizedEmail = email.trim().toLowerCase()
-    const timeout = setTimeout(() => {
-      const isAuthorized = AUTHORIZED_EMAILS.includes(normalizedEmail)
-      setVerificationStatus(isAuthorized ? 'success' : 'error')
-    }, 1200)
+    let cancelled = false
+
+    async function verifyWhitelist() {
+      setVerificationStatus('checking')
+      setVerificationError(null)
+
+      try {
+        if (!canSubmitLogin) {
+          throw new Error('Revisa el correo y la contraseña antes de continuar.')
+        }
+
+        const whitelistRef = doc(db, 'authorizedEmails', normalizedEmail)
+        const whitelistSnap = await getDoc(whitelistRef)
+
+        if (!whitelistSnap.exists()) {
+          throw new Error('Tu correo no forma parte de la whitelist habilitada para el evento.')
+        }
+
+        const whitelistData = whitelistSnap.data()
+        const entry = mapAuthorizedEntry(normalizedEmail, whitelistData)
+
+        if (!cancelled) {
+          setAuthorizedEntry(entry)
+        }
+
+        let currentUser = auth.currentUser
+        const isDifferentUser = currentUser?.email?.toLowerCase() !== normalizedEmail
+
+        if (!currentUser || isDifferentUser) {
+          try {
+            const { user: signedUser } = await signInWithEmailAndPassword(auth, normalizedEmail, password)
+            currentUser = signedUser
+          } catch (error) {
+            const mapped = mapAuthError(error)
+            if (mapped.code === 'auth/user-not-found') {
+              const { user: createdUser } = await createUserWithEmailAndPassword(auth, normalizedEmail, password)
+              currentUser = createdUser
+            } else {
+              throw new Error(mapped.message)
+            }
+          }
+        }
+
+        if (!currentUser) {
+          throw new Error('No se pudo establecer tu sesión. Intenta de nuevo en unos segundos.')
+        }
+
+        const profileRef = doc(db, 'users', currentUser.uid)
+        const profileSnap = await getDoc(profileRef)
+
+        if (!cancelled) {
+          if (profileSnap.exists()) {
+            const data = profileSnap.data()
+            setAlias((prev) => prev || data.alias || entry.displayName || normalizedEmail.split('@')[0])
+            setFullName(data.fullName ?? '')
+            setLanguage((data.language as LanguageOption | undefined) ?? 'es')
+            setConsent(Boolean(data.consentAt))
+          } else {
+            setAlias((prev) => prev || entry.displayName || normalizedEmail.split('@')[0])
+            setFullName('')
+            setConsent(false)
+          }
+
+          setProfilePrefilled(false)
+          setVerificationStatus('success')
+          setCurrentStep('profile')
+        }
+      } catch (error) {
+        if (cancelled) {
+          return
+        }
+
+        setVerificationStatus('error')
+        setVerificationError(error instanceof Error ? error.message : 'No se pudo validar tu acceso. Intenta nuevamente.')
+        if (auth.currentUser && auth.currentUser.email?.toLowerCase() !== normalizedEmail) {
+          signOut(auth).catch(() => undefined)
+        }
+      }
+    }
+
+    verifyWhitelist()
 
     return () => {
-      clearTimeout(timeout)
+      cancelled = true
     }
-  }, [currentStep, email, verificationAttempt])
+  }, [canSubmitLogin, currentStep, normalizedEmail, password, verificationAttempt])
 
   useEffect(() => {
     if (showLoginErrors && canSubmitLogin) {
@@ -101,8 +196,31 @@ export function Access() {
   useEffect(() => {
     if (currentStep !== 'profile') {
       setProfileSaved(false)
+      setProfilePrefilled(false)
+      return
     }
-  }, [currentStep])
+
+    if (profilePrefilled) {
+      return
+    }
+
+    if (profile) {
+      setAlias((prev) => (prev ? prev : profile.alias ?? authorizedEntry?.displayName ?? normalizedEmail.split('@')[0]))
+      setFullName(profile.fullName ?? '')
+      setLanguage((profile.language as LanguageOption | undefined) ?? 'es')
+      setConsent(Boolean(profile.consentAt))
+      setProfilePrefilled(true)
+      return
+    }
+
+    if (authorizedEntry?.displayName) {
+      setAlias((prev) => prev || authorizedEntry.displayName || '')
+    } else if (normalizedEmail) {
+      setAlias((prev) => prev || normalizedEmail.split('@')[0])
+    }
+
+    setProfilePrefilled(true)
+  }, [authorizedEntry, currentStep, normalizedEmail, profile, profilePrefilled])
 
   useEffect(() => {
     setProfileSaved(false)
@@ -126,25 +244,49 @@ export function Access() {
 
   const handleRetryVerification = () => {
     setVerificationAttempt((attempt) => attempt + 1)
+    setVerificationStatus('idle')
   }
 
   const handleBackToLogin = () => {
     setVerificationStatus('idle')
+    setVerificationError(null)
+    signOut(auth).catch(() => undefined)
     setCurrentStep('login')
   }
 
-  const handleGoToProfile = () => {
-    setCurrentStep('profile')
-  }
-
-  const handleProfileSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleProfileSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
 
-    if (!canFinishProfile) {
+    if (!canFinishProfile || !auth.currentUser) {
       return
     }
 
-    setProfileSaved(true)
+    setSavingProfile(true)
+    setProfileError(null)
+
+    try {
+      const profileRef = doc(db, 'users', auth.currentUser.uid)
+      await setDoc(
+        profileRef,
+        {
+          alias: alias.trim(),
+          fullName: fullName.trim() || null,
+          language,
+          bio: profile?.bio ?? null,
+          consentAt: consent ? serverTimestamp() : null,
+          role: authorizedEntry?.role ?? profile?.role ?? null,
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true },
+      )
+
+      setProfileSaved(true)
+      navigate('/')
+    } catch (error) {
+      setProfileError(error instanceof Error ? error.message : 'No se pudo guardar el perfil. Vuelve a intentarlo más tarde.')
+    } finally {
+      setSavingProfile(false)
+    }
   }
 
   let mainContent: JSX.Element
@@ -191,10 +333,7 @@ export function Access() {
               Comenzar acceso
               <ArrowRight className="h-4 w-4" />
             </button>
-            <a
-              href={`mailto:${SUPPORT_EMAIL}`}
-              className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
-            >
+            <a href={`mailto:${SUPPORT_EMAIL}`} className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline">
               <MailCheck className="h-4 w-4" />
               ¿Necesitas ayuda? Escríbenos
             </a>
@@ -204,214 +343,185 @@ export function Access() {
       break
     case 'login':
       mainContent = (
-        <form onSubmit={handleLoginSubmit} className="space-y-5">
-          <div className="grid gap-4 md:grid-cols-2">
-            <label className="rounded-2xl border border-primary/20 px-4 py-3 text-sm text-text-secondary">
-              <span className="text-xs uppercase tracking-wide">Correo electrónico</span>
-              <input
-                type="email"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                className="mt-1 w-full bg-transparent text-base text-text-primary outline-none"
-                placeholder="usuario@juegoscongreso.com"
-                required
-              />
-            </label>
-            <label className="rounded-2xl border border-primary/20 px-4 py-3 text-sm text-text-secondary">
-              <span className="text-xs uppercase tracking-wide">Contraseña</span>
-              <input
-                type="password"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                className="mt-1 w-full bg-transparent text-base text-text-primary outline-none"
-                placeholder="Mínimo 8 caracteres"
-                required
-              />
-            </label>
+        <form onSubmit={handleLoginSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <label className="text-sm font-semibold text-text-primary">Correo autorizado</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className={clsx(
+                'w-full rounded-2xl border bg-background px-4 py-3 text-sm outline-none transition focus:border-primary/60 focus:ring-2 focus:ring-primary/20',
+                showLoginErrors && !isEmailValid ? 'border-error text-error' : 'border-slate-200 text-text-primary',
+              )}
+              placeholder="tucorreo@organizacion.com"
+              autoComplete="email"
+              required
+            />
+            {showLoginErrors && !isEmailValid && <p className="text-sm text-error">Introduce un correo válido.</p>}
           </div>
+          <div className="space-y-2">
+            <label className="text-sm font-semibold text-text-primary">Contraseña</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className={clsx(
+                'w-full rounded-2xl border bg-background px-4 py-3 text-sm outline-none transition focus:border-primary/60 focus:ring-2 focus:ring-primary/20',
+                showLoginErrors && !isPasswordValid ? 'border-error text-error' : 'border-slate-200 text-text-primary',
+              )}
+              placeholder="Mínimo 8 caracteres"
+              autoComplete="current-password"
+              required
+            />
+            {showLoginErrors && !isPasswordValid && (
+              <p className="text-sm text-error">La contraseña debe tener al menos 8 caracteres.</p>
+            )}
+          </div>
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-3 text-sm font-semibold text-white shadow-card transition-colors hover:bg-primary/90"
+          >
+            Continuar
+            <ArrowRight className="h-4 w-4" />
+          </button>
           <p className="text-xs text-text-secondary">
-            Por seguridad, evitamos contraseñas comunes. Puedes cambiarla después desde tu perfil.
+            Si todavía no tienes credenciales, solicita el alta a la organización del congreso.
           </p>
-          {showLoginErrors && !canSubmitLogin && (
-            <div className="rounded-2xl border border-error/30 bg-error/10 px-4 py-3 text-sm text-error">
-              Revisa el formato del correo e introduce una contraseña con al menos 8 caracteres.
-            </div>
-          )}
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <button
-              type="button"
-              onClick={() => setCurrentStep('welcome')}
-              className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold text-text-secondary transition-colors hover:bg-primary/10 hover:text-primary"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Volver a la bienvenida
-            </button>
-            <button
-              type="submit"
-              className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-card transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/50"
-              disabled={!canSubmitLogin}
-            >
-              Continuar con whitelist
-              <ArrowRight className="h-4 w-4" />
-            </button>
-          </div>
         </form>
       )
       break
     case 'verification':
       mainContent = (
-        <div className="space-y-5" aria-live="polite">
-          {verificationStatus === 'checking' && (
-            <div className="flex items-start gap-3 rounded-2xl border border-primary/20 bg-primary/5 px-4 py-3 text-sm text-text-secondary">
-              <Loader2 className="h-5 w-5 animate-spin text-primary" />
-              <div>
-                <p className="font-semibold text-text-primary">Validando whitelist…</p>
-                <p>Estamos comprobando que {email} esté autorizado para el evento.</p>
-              </div>
-            </div>
-          )}
-          {verificationStatus === 'success' && (
-            <div className="flex items-start gap-3 rounded-2xl border border-success/30 bg-success/10 px-4 py-3 text-sm text-success" role="status">
-              <CheckCircle2 className="h-5 w-5" />
-              <div>
-                <p className="font-semibold text-text-primary">¡Acceso concedido!</p>
-                <p className="text-text-secondary">{email} forma parte de la lista autorizada. Puedes completar tu perfil.</p>
-              </div>
-            </div>
-          )}
-          {verificationStatus === 'error' && (
-            <div className="flex items-start gap-3 rounded-2xl border border-error/30 bg-error/10 px-4 py-3 text-sm text-error" role="alert">
-              <ShieldAlert className="h-5 w-5" />
-              <div>
-                <p className="font-semibold text-text-primary">Correo no encontrado</p>
-                <p className="text-text-secondary">
-                  No localizamos {email} en la whitelist. Verifica que uses el correo invitado o contacta con la organización.
-                </p>
-              </div>
-            </div>
-          )}
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <button
-              type="button"
-              onClick={handleBackToLogin}
-              className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold text-text-secondary transition-colors hover:bg-primary/10 hover:text-primary"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Cambiar correo
-            </button>
-            {verificationStatus === 'success' ? (
-              <button
-                type="button"
-                onClick={handleGoToProfile}
-                className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-card transition-colors hover:bg-primary/90"
-              >
-                Completar perfil inicial
-                <ArrowRight className="h-4 w-4" />
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={handleRetryVerification}
-                className="inline-flex items-center justify-center gap-2 rounded-full border border-primary px-5 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary hover:text-white"
-              >
-                Reintentar verificación
-              </button>
-            )}
+        <div className="space-y-6">
+          <div className="rounded-2xl border border-primary/20 bg-primary/5 px-4 py-4 text-sm text-text-secondary">
+            <p className="flex items-center gap-2 text-base font-semibold text-text-primary">
+              {verificationStatus === 'success' ? (
+                <CheckCircle2 className="h-5 w-5 text-secondary" />
+              ) : verificationStatus === 'error' ? (
+                <ShieldAlert className="h-5 w-5 text-error" />
+              ) : (
+                <Loader2 className="h-5 w-5 animate-spin text-primary" />
+              )}
+              Verificando acceso para <span className="font-mono text-primary">{normalizedEmail}</span>
+            </p>
+            <p>
+              {verificationStatus === 'checking' && 'Consultando la whitelist y tus credenciales en Firebase Auth...'}
+              {verificationStatus === 'success' && 'Tu correo está autorizado. Vamos a completar tu perfil inicial.'}
+              {verificationStatus === 'error' && verificationError}
+            </p>
           </div>
+          {verificationStatus === 'error' && (
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <button
+                onClick={handleRetryVerification}
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-3 text-sm font-semibold text-white shadow-card transition-colors hover:bg-primary/90"
+              >
+                Reintentar
+              </button>
+              <button
+                onClick={handleBackToLogin}
+                className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 px-5 py-3 text-sm font-semibold text-text-primary transition-colors hover:bg-background"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Cambiar datos
+              </button>
+            </div>
+          )}
         </div>
       )
       break
     case 'profile':
       mainContent = (
-        <form onSubmit={handleProfileSubmit} className="space-y-5">
+        <form onSubmit={handleProfileSubmit} className="space-y-6">
+          <div className="rounded-2xl border border-primary/20 bg-primary/5 px-4 py-3 text-sm text-text-secondary">
+            <p className="text-base font-semibold text-text-primary">Datos autorizados</p>
+            <p>
+              <span className="font-medium text-text-primary">Correo:</span> {normalizedEmail || user?.email || 'Pendiente'}
+            </p>
+            {authorizedEntry?.role && (
+              <p>
+                <span className="font-medium text-text-primary">Rol asignado:</span> {authorizedEntry.role}
+              </p>
+            )}
+          </div>
           <div className="grid gap-4 md:grid-cols-2">
             <label className="rounded-2xl border border-primary/20 px-4 py-3 text-sm text-text-secondary">
-              <span className="text-xs uppercase tracking-wide">Alias visible</span>
+              <span className="text-xs uppercase tracking-wide">Alias visible *</span>
               <input
+                className="mt-1 w-full bg-transparent text-base text-text-primary outline-none"
                 value={alias}
                 onChange={(event) => setAlias(event.target.value)}
-                className="mt-1 w-full bg-transparent text-base text-text-primary outline-none"
-                placeholder="Ej. Alex, MeepleHero…"
+                minLength={2}
                 required
               />
             </label>
             <label className="rounded-2xl border border-primary/20 px-4 py-3 text-sm text-text-secondary">
-              <span className="text-xs uppercase tracking-wide">Nombre (opcional)</span>
+              <span className="text-xs uppercase tracking-wide">Nombre completo (opcional)</span>
               <input
+                className="mt-1 w-full bg-transparent text-base text-text-primary outline-none"
                 value={fullName}
                 onChange={(event) => setFullName(event.target.value)}
-                className="mt-1 w-full bg-transparent text-base text-text-primary outline-none"
                 placeholder="Nombre y apellidos"
               />
             </label>
             <label className="rounded-2xl border border-primary/20 px-4 py-3 text-sm text-text-secondary">
               <span className="text-xs uppercase tracking-wide">Idioma preferido</span>
-              <select
-                value={language}
-                onChange={(event) => setLanguage(event.target.value as LanguageOption)}
-                className="mt-1 w-full bg-transparent text-base text-text-primary outline-none"
-              >
-                <option value="es">Español</option>
-                <option value="en">English</option>
-              </select>
+              <div className="mt-1 flex items-center gap-2">
+                <select
+                  className="w-full rounded-xl bg-background px-3 py-2 text-base text-text-primary outline-none"
+                  value={language}
+                  onChange={(event) => setLanguage(event.target.value as LanguageOption)}
+                >
+                  <option value="es">Español</option>
+                  <option value="en">English</option>
+                </select>
+              </div>
             </label>
-            <label className="rounded-2xl border border-dashed border-primary/30 px-4 py-3 text-sm text-text-secondary md:col-span-2">
-              <span className="text-xs uppercase tracking-wide">Consentimiento RGPD</span>
-              <div className="mt-2 flex items-start justify-between gap-4">
-                <p className="text-sm text-text-secondary">
-                  Autorizo el tratamiento de mis datos personales durante el congreso y comprendo que puedo solicitar la baja en
-                  cualquier momento.
-                </p>
+            <label className="rounded-2xl border border-primary/20 px-4 py-3 text-sm text-text-secondary">
+              <span className="text-xs uppercase tracking-wide">Consentimiento *</span>
+              <div className="mt-2 flex items-center gap-3">
                 <input
                   type="checkbox"
                   checked={consent}
                   onChange={(event) => setConsent(event.target.checked)}
-                  className="mt-1 h-5 w-10 cursor-pointer rounded-full accent-primary"
+                  className="h-5 w-5 rounded-md border border-slate-200 text-primary focus:ring-primary"
+                  required
                 />
+                <span>Acepto participar en el evento y que se registren mis partidas durante el congreso.</span>
               </div>
             </label>
           </div>
-          {!isAliasValid && (
-            <p className="text-xs text-error">El alias debe tener al menos 2 caracteres.</p>
+          {profileError && (
+            <p className="rounded-xl border border-error/30 bg-error/5 px-3 py-2 text-sm text-error">{profileError}</p>
           )}
-          {!consent && (
-            <p className="text-xs text-text-secondary">
-              Debes aceptar el consentimiento para participar y recibir comunicaciones del evento.
-            </p>
-          )}
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <button
-              type="button"
-              onClick={() => setCurrentStep('verification')}
-              className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold text-text-secondary transition-colors hover:bg-primary/10 hover:text-primary"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Revisar whitelist
-            </button>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
             <button
               type="submit"
               disabled={!canFinishProfile}
-              className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-card transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/50"
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-3 text-sm font-semibold text-white shadow-card transition-colors disabled:cursor-not-allowed disabled:bg-primary/60"
             >
-              Guardar y entrar en la app
-              <ArrowRight className="h-4 w-4" />
+              {savingProfile ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" /> Guardando...
+                </>
+              ) : (
+                <>
+                  Finalizar acceso
+                  <CheckCircle2 className="h-4 w-4" />
+                </>
+              )}
             </button>
+            {profileSaved && (
+              <Link
+                to="/"
+                className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-5 py-3 text-sm font-semibold text-text-primary transition-colors hover:bg-background"
+              >
+                <UserRound className="h-4 w-4" />
+                Entrar a la app
+              </Link>
+            )}
           </div>
-          {profileSaved && (
-            <div className="flex items-start gap-3 rounded-2xl border border-success/30 bg-success/10 px-4 py-3 text-sm text-success" role="status">
-              <CheckCircle2 className="h-5 w-5" />
-              <div>
-                <p className="font-semibold text-text-primary">Perfil guardado</p>
-                <p className="text-text-secondary">
-                  ¡Todo listo! Serás redirigido a la Home del evento para comenzar a registrar partidas.
-                </p>
-                <Link to="/" className="mt-2 inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline">
-                  Ir ahora a la Home
-                  <ArrowRight className="h-4 w-4" />
-                </Link>
-              </div>
-            </div>
-          )}
         </form>
       )
       break
@@ -419,174 +529,87 @@ export function Access() {
       mainContent = <div />
   }
 
-  let asideContent: JSX.Element
-  switch (currentStep) {
-    case 'welcome':
-      asideContent = (
-        <div className="space-y-4 text-sm text-text-secondary">
-          <div className="rounded-2xl bg-surface px-4 py-3">
-            <p className="text-sm font-semibold text-text-primary">Horario del día</p>
-            <p>07:00 – 06:59. Las estadísticas se agrupan usando esta frontera horaria.</p>
-          </div>
-          <div className="rounded-2xl bg-surface px-4 py-3">
-            <p className="text-sm font-semibold text-text-primary">Documentación</p>
-            <p>Consulta el PRD y las reglas del evento desde tu perfil una vez dentro.</p>
-          </div>
-        </div>
-      )
-      break
-    case 'login':
-      asideContent = (
-        <div className="space-y-4 text-sm text-text-secondary">
-          <div className="rounded-2xl bg-surface px-4 py-3">
-            <p className="text-sm font-semibold text-text-primary">Correos autorizados</p>
-            <ul className="mt-2 space-y-2">
-              {AUTHORIZED_EMAILS.slice(0, 3).map((authorized) => (
-                <li key={authorized}>• {authorized}</li>
-              ))}
-              <li>• alejandro.martin.millan@gmail.com (organización)</li>
-            </ul>
-          </div>
-          <div className="rounded-2xl bg-surface px-4 py-3">
-            <p className="text-sm font-semibold text-text-primary">Consejo</p>
-            <p>
-              Si alguien no aparece en la whitelist, solicita a la organización que lo añada desde el panel administrativo.
-            </p>
-          </div>
-        </div>
-      )
-      break
-    case 'verification':
-      asideContent = (
-        <div className="space-y-4 text-sm text-text-secondary">
-          <div className="rounded-2xl bg-surface px-4 py-3">
-            <p className="text-sm font-semibold text-text-primary">Tiempo estimado</p>
-            <p>La comprobación suele tardar menos de 2 segundos gracias al uso de Cloud Functions.</p>
-          </div>
-          <div className="rounded-2xl bg-surface px-4 py-3">
-            <p className="text-sm font-semibold text-text-primary">Soporte</p>
-            <p>
-              ¿Error inesperado? Envía un correo a{' '}
-              <a href={`mailto:${SUPPORT_EMAIL}`} className="font-semibold text-primary hover:underline">
-                {SUPPORT_EMAIL}
-              </a>{' '}
-              con tu nombre y captura para revisarlo.
-            </p>
-          </div>
-        </div>
-      )
-      break
-    case 'profile':
-      asideContent = (
-        <div className="space-y-4 text-sm text-text-secondary">
-          <div className="rounded-2xl bg-surface px-4 py-3">
-            <p className="text-sm font-semibold text-text-primary">Resumen provisional</p>
-            <ul className="mt-2 space-y-2">
-              <li className="flex items-center gap-2">
-                <UserRound className="h-4 w-4 text-primary" />
-                <span className="text-text-primary">Alias:</span> {alias || '—'}
-              </li>
-              <li className="flex items-center gap-2">
-                <MailCheck className="h-4 w-4 text-primary" />
-                <span className="text-text-primary">Email:</span> {email}
-              </li>
-              <li>
-                <span className="text-text-primary">Idioma:</span> {language === 'es' ? 'Español' : 'English'}
-              </li>
-              <li>
-                <span className="text-text-primary">Consentimiento:</span> {consent ? 'Aceptado' : 'Pendiente'}
-              </li>
-            </ul>
-          </div>
-          <div className="rounded-2xl bg-surface px-4 py-3">
-            <p className="text-sm font-semibold text-text-primary">Siguiente paso</p>
-            <p>Una vez guardado, accederás a la Home con métricas del día y accesos rápidos.</p>
-          </div>
-        </div>
-      )
-      break
-    default:
-      asideContent = <div />
-  }
-
   return (
     <div className="min-h-screen bg-background text-text-primary">
-      <div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col px-4 py-10">
-        <header className="mb-8 flex flex-col items-center gap-3 text-center">
-          <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-sm font-semibold text-primary">
-            <Sparkles className="h-4 w-4" />
-            Acceso al congreso
-          </span>
-          <h1 className="text-3xl font-semibold text-text-primary">Completa el onboarding en cuatro pasos</h1>
-          <p className="text-sm text-text-secondary">
-            Usa tu email autorizado, valida la whitelist y establece tu perfil antes de entrar en la app.
-          </p>
-          <Link
-            to="/"
-            className="inline-flex items-center gap-2 text-sm font-semibold text-primary transition-colors hover:text-primary/80"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Volver a la Home
-          </Link>
-        </header>
-
-        <div className="card flex-1 space-y-6 p-6 md:p-8">
-          <div className="space-y-4">
-            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <div className="text-left md:text-left">
-                <p className="text-xs uppercase tracking-wide text-text-secondary">
-                  Paso {activeIndex + 1} de {onboardingSteps.length}
-                </p>
-                <h2 className="text-xl font-semibold text-text-primary">{activeStep.title}</h2>
-                <p className="text-sm text-text-secondary">{activeStep.description}</p>
-              </div>
-              <div className="min-w-[160px]">
-                <div className="h-2 rounded-full bg-background">
-                  <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${progress}%` }} />
-                </div>
-                <p className="mt-2 text-right text-xs text-text-secondary">{Math.round(progress)}% completado</p>
-              </div>
-            </div>
-            <div className="grid gap-3 md:grid-cols-4">
-              {onboardingSteps.map((step, index) => {
-                const isComplete = index < activeIndex
-                const isActive = index === activeIndex
-
-                return (
-                  <div
-                    key={step.key}
-                    className={clsx(
-                      'rounded-2xl border px-3 py-3 text-left transition-colors',
-                      isActive && 'border-primary bg-primary/10 text-primary',
-                      isComplete && !isActive && 'border-primary/30 bg-background text-primary',
-                      index > activeIndex && 'border-transparent bg-background text-text-secondary',
-                    )}
-                  >
-                    <p className="text-xs uppercase tracking-wide">Paso {index + 1}</p>
-                    <p className="text-sm font-semibold">{step.title}</p>
-                  </div>
-                )
-              })}
-            </div>
+      <div className="mx-auto flex min-h-screen max-w-screen-md flex-col px-4 pb-16 pt-10 sm:px-8">
+        <header className="mb-10 space-y-4">
+          <div className="flex items-center justify-between">
+            <Link to="/" className="inline-flex items-center gap-2 text-sm font-semibold text-text-secondary hover:text-primary">
+              <ArrowLeft className="h-4 w-4" />
+              Volver
+            </Link>
+            <span className="rounded-full bg-primary/10 px-4 py-1 text-xs font-semibold text-primary">Acceso privado</span>
           </div>
-
-          <div className="grid flex-1 gap-6 md:grid-cols-[1.6fr,1fr]">
-            <section className="space-y-5">{mainContent}</section>
-            <aside className="rounded-2xl bg-background px-4 py-4">{asideContent}</aside>
-          </div>
-
-          <footer className="rounded-2xl border border-primary/20 bg-primary/5 px-4 py-3 text-sm text-text-secondary">
-            <p className="font-semibold text-text-primary">Soporte del evento</p>
-            <p>
-              Ante cualquier incidencia durante el acceso, escribe a{' '}
-              <a href={`mailto:${SUPPORT_EMAIL}`} className="font-semibold text-primary hover:underline">
-                {SUPPORT_EMAIL}
-              </a>
-              . El equipo responde en menos de 12 horas.
+          <div>
+            <h1 className="text-2xl font-semibold text-text-primary">Acceso al evento</h1>
+            <p className="text-sm text-text-secondary">
+              Completa los pasos para verificar tu invitación y activar tu cuenta en la plataforma del congreso.
             </p>
-          </footer>
-        </div>
+          </div>
+          <div className="rounded-full bg-background shadow-card">
+            <div className="relative h-2 overflow-hidden rounded-full bg-slate-200">
+              <div className="absolute inset-y-0 left-0 bg-primary transition-all" style={{ width: `${progress}%` }} />
+            </div>
+            <div className="mt-3 flex items-center justify-between text-xs font-semibold text-text-secondary">
+              {onboardingSteps.map((step, index) => (
+                <div key={step.key} className="flex flex-col items-center">
+                  <span className={clsx('mb-1 h-2 w-2 rounded-full', index <= activeIndex ? 'bg-primary' : 'bg-slate-300')} />
+                  <span>{step.title}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </header>
+        <main className="flex-1">
+          <div className="card space-y-6 p-6">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-text-secondary">Paso actual</p>
+              <h2 className="mt-1 text-xl font-semibold text-text-primary">{activeStep.title}</h2>
+              <p className="text-sm text-text-secondary">{activeStep.description}</p>
+            </div>
+            {mainContent}
+          </div>
+        </main>
       </div>
     </div>
   )
+}
+
+function mapAuthorizedEntry(email: string, data: DocumentData | undefined): AuthorizedEntry {
+  return {
+    email,
+    role: data?.role ?? undefined,
+    displayName: data?.displayName ?? undefined,
+  }
+}
+
+type AuthError = {
+  code: string
+  message: string
+}
+
+function mapAuthError(error: unknown): AuthError {
+  if (typeof error === 'object' && error && 'code' in error && 'message' in error) {
+    const firebaseError = error as FirebaseError
+    switch (firebaseError.code) {
+      case 'auth/invalid-email':
+        return { code: firebaseError.code, message: 'El formato de correo no es válido.' }
+      case 'auth/invalid-credential':
+      case 'auth/wrong-password':
+        return { code: firebaseError.code, message: 'La contraseña no es correcta para este usuario.' }
+      case 'auth/too-many-requests':
+        return {
+          code: firebaseError.code,
+          message: 'Hemos bloqueado temporalmente tu acceso por múltiples intentos fallidos. Prueba nuevamente en unos minutos.',
+        }
+      case 'auth/user-disabled':
+        return { code: firebaseError.code, message: 'Esta cuenta ha sido deshabilitada. Contacta con la organización.' }
+      case 'auth/user-not-found':
+        return { code: firebaseError.code, message: 'No encontramos una cuenta activa. Crearemos una nueva para ti.' }
+      default:
+        return { code: firebaseError.code, message: firebaseError.message }
+    }
+  }
+
+  return { code: 'unknown', message: 'Ocurrió un error inesperado al validar tus credenciales.' }
 }

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,7 +1,114 @@
-import { Languages, LogOut, ShieldCheck, UserCog } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Languages, Loader2, LogOut, ShieldCheck, UserCog, CheckCircle2 } from 'lucide-react'
 import { Link } from 'react-router-dom'
+import { doc, serverTimestamp, setDoc } from 'firebase/firestore'
+import { useAuth } from '../components/AuthProvider'
+import { db } from '../utils/firebase'
+
+const SUPPORT_EMAIL = 'soporte@juegoscongreso.com'
+
+type PreferencesState = {
+  notifications: boolean
+  darkMode: boolean
+  availableToPlay: boolean
+}
 
 export function Profile() {
+  const { user, profile, profileLoading, authorized, signOut } = useAuth()
+  const [alias, setAlias] = useState('')
+  const [language, setLanguage] = useState<'es' | 'en'>('es')
+  const [bio, setBio] = useState('')
+  const [preferences, setPreferences] = useState<PreferencesState>({
+    notifications: false,
+    darkMode: false,
+    availableToPlay: false,
+  })
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveMessage, setSaveMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!profileLoading) {
+      setAlias(profile?.alias ?? '')
+      setLanguage((profile?.language as 'es' | 'en' | undefined) ?? 'es')
+      setBio(profile?.bio ?? '')
+      setPreferences({
+        notifications: profile?.preferences?.notifications ?? false,
+        darkMode: profile?.preferences?.darkMode ?? false,
+        availableToPlay: profile?.preferences?.availableToPlay ?? false,
+      })
+    }
+  }, [profile, profileLoading])
+
+  useEffect(() => {
+    if (saveMessage) {
+      const timeout = setTimeout(() => setSaveMessage(null), 4000)
+      return () => clearTimeout(timeout)
+    }
+  }, [saveMessage])
+
+  const initials = useMemo(() => {
+    if (alias) {
+      return alias
+        .split(' ')
+        .filter(Boolean)
+        .slice(0, 2)
+        .map((part) => part[0]?.toUpperCase())
+        .join('')
+    }
+
+    if (user?.email) {
+      return user.email.slice(0, 2).toUpperCase()
+    }
+
+    return '??'
+  }, [alias, user?.email])
+
+  const email = user?.email ?? 'Correo no disponible'
+  const roleValue = authorized?.role ?? profile?.role ?? null
+  const roleLabel = roleValue ? roleValue.charAt(0).toUpperCase() + roleValue.slice(1) : 'Asistente'
+
+  const handlePreferenceChange = (key: keyof PreferencesState) => (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPreferences((current) => ({ ...current, [key]: event.target.checked }))
+  }
+
+  const handleSave = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!user) {
+      return
+    }
+
+    setSaving(true)
+    setSaveError(null)
+    setSaveMessage(null)
+
+    try {
+      await setDoc(
+        doc(db, 'users', user.uid),
+        {
+          alias: alias.trim() || null,
+          language,
+          bio: bio.trim() || null,
+          role: roleValue,
+          preferences,
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true },
+      )
+
+      setSaveMessage('Cambios guardados correctamente.')
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : 'No se pudieron guardar los cambios.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSignOut = () => {
+    signOut().catch(() => undefined)
+  }
+
   return (
     <div className="space-y-6 pb-10">
       <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
@@ -9,39 +116,54 @@ export function Profile() {
           <h2 className="section-title">Tu perfil</h2>
           <p className="text-sm text-text-secondary">Gestiona datos personales, preferencias y accesos especiales.</p>
         </div>
-        <button className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold text-error transition-colors hover:bg-error/10">
+        <button
+          onClick={handleSignOut}
+          className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold text-error transition-colors hover:bg-error/10"
+        >
           <LogOut className="h-4 w-4" />
           Cerrar sesión
         </button>
       </header>
 
-      <section className="grid gap-6 md:grid-cols-[1.5fr,1fr]">
+      <form onSubmit={handleSave} className="grid gap-6 md:grid-cols-[1.5fr,1fr]">
         <div className="card space-y-5 p-6">
           <div className="flex items-center gap-4">
-            <div className="h-16 w-16 rounded-2xl bg-primary/10 text-2xl font-semibold text-primary flex items-center justify-center">
-              AL
+            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 text-2xl font-semibold text-primary">
+              {initials}
             </div>
             <div>
-              <h3 className="text-lg font-semibold text-text-primary">Alejandro Martín</h3>
-              <p className="text-sm text-text-secondary">alejandro.martin.millan@gmail.com</p>
+              <h3 className="text-lg font-semibold text-text-primary">{alias || authorized?.displayName || 'Alias pendiente'}</h3>
+              <p className="text-sm text-text-secondary">{email}</p>
               <span className="mt-1 inline-flex items-center gap-2 rounded-full bg-secondary/20 px-3 py-1 text-xs font-semibold text-secondary">
                 <ShieldCheck className="h-4 w-4" />
-                Organización
+                {roleLabel}
               </span>
             </div>
           </div>
+
           <div className="grid gap-4 md:grid-cols-2">
             <label className="rounded-2xl border border-primary/20 px-4 py-3 text-sm text-text-secondary">
               <span className="text-xs uppercase tracking-wide">Alias visible</span>
-              <input className="mt-1 w-full bg-transparent text-base text-text-primary outline-none" defaultValue="Alex M." />
+              <input
+                className="mt-1 w-full bg-transparent text-base text-text-primary outline-none"
+                value={alias}
+                onChange={(event) => setAlias(event.target.value)}
+                placeholder="Introduce un alias público"
+                minLength={2}
+                required
+              />
             </label>
             <label className="rounded-2xl border border-primary/20 px-4 py-3 text-sm text-text-secondary">
               <span className="text-xs uppercase tracking-wide">Idioma preferido</span>
               <div className="mt-1 flex items-center gap-2">
                 <Languages className="h-4 w-4 text-text-secondary" />
-                <select className="w-full bg-transparent text-base text-text-primary outline-none">
-                  <option>Español</option>
-                  <option>English</option>
+                <select
+                  className="w-full bg-transparent text-base text-text-primary outline-none"
+                  value={language}
+                  onChange={(event) => setLanguage(event.target.value as 'es' | 'en')}
+                >
+                  <option value="es">Español</option>
+                  <option value="en">English</option>
                 </select>
               </div>
             </label>
@@ -49,10 +171,32 @@ export function Profile() {
               <span className="text-xs uppercase tracking-wide">Bio</span>
               <textarea
                 className="mt-1 h-20 w-full resize-none bg-transparent text-sm text-text-secondary outline-none"
+                value={bio}
+                onChange={(event) => setBio(event.target.value)}
                 placeholder="Cuéntale a la comunidad qué juegos te apasionan"
               />
             </label>
           </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <button
+              type="submit"
+              disabled={saving}
+              className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-card transition-colors disabled:cursor-not-allowed disabled:bg-primary/60"
+            >
+              {saving ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" /> Guardando...
+                </>
+              ) : (
+                <>
+                  <CheckCircle2 className="h-4 w-4" /> Guardar cambios
+                </>
+              )}
+            </button>
+            {saveMessage && <p className="text-sm text-text-secondary">{saveMessage}</p>}
+          </div>
+          {saveError && <p className="rounded-xl border border-error/30 bg-error/5 px-3 py-2 text-sm text-error">{saveError}</p>}
         </div>
 
         <aside className="card space-y-4 p-6">
@@ -63,29 +207,49 @@ export function Profile() {
                 <p className="font-semibold text-text-primary">Notificaciones push</p>
                 <p>Chat de partidas, tablón y recordatorios de agenda.</p>
               </div>
-              <input type="checkbox" defaultChecked className="h-5 w-10 cursor-pointer rounded-full accent-primary" />
+              <input
+                type="checkbox"
+                checked={preferences.notifications}
+                onChange={handlePreferenceChange('notifications')}
+                className="h-5 w-10 cursor-pointer rounded-full accent-primary"
+              />
             </label>
             <label className="flex items-center justify-between rounded-2xl bg-background px-4 py-3">
               <div>
                 <p className="font-semibold text-text-primary">Modo oscuro automático</p>
                 <p>Se adapta al sistema de tu dispositivo.</p>
               </div>
-              <input type="checkbox" className="h-5 w-10 cursor-pointer rounded-full accent-primary" />
+              <input
+                type="checkbox"
+                checked={preferences.darkMode}
+                onChange={handlePreferenceChange('darkMode')}
+                className="h-5 w-10 cursor-pointer rounded-full accent-primary"
+              />
             </label>
             <label className="flex items-center justify-between rounded-2xl bg-background px-4 py-3">
               <div>
                 <p className="font-semibold text-text-primary">Mostrarme disponible</p>
                 <p>Aparecerás en el tablón como persona abierta a nuevas partidas.</p>
               </div>
-              <input type="checkbox" defaultChecked className="h-5 w-10 cursor-pointer rounded-full accent-primary" />
+              <input
+                type="checkbox"
+                checked={preferences.availableToPlay}
+                onChange={handlePreferenceChange('availableToPlay')}
+                className="h-5 w-10 cursor-pointer rounded-full accent-primary"
+              />
             </label>
           </div>
           <div className="rounded-2xl border border-primary/20 bg-primary/5 px-4 py-3 text-sm text-text-secondary">
             <p className="font-semibold text-text-primary">Centro de soporte</p>
-            <p>¿Dudas sobre privacidad o baja del evento? Escríbenos a soporte@juegoscongreso.com</p>
+            <p>
+              ¿Dudas sobre privacidad o baja del evento? Escríbenos a{' '}
+              <a href={`mailto:${SUPPORT_EMAIL}`} className="text-primary underline">
+                {SUPPORT_EMAIL}
+              </a>
+            </p>
           </div>
         </aside>
-      </section>
+      </form>
 
       <section className="card space-y-4 p-6">
         <div className="flex items-center justify-between">
@@ -101,15 +265,15 @@ export function Profile() {
         <div className="grid gap-4 md:grid-cols-3">
           <div className="rounded-2xl bg-background px-4 py-3">
             <p className="text-xs uppercase tracking-wide text-text-secondary">Asistentes activos</p>
-            <p className="text-2xl font-semibold text-text-primary">86</p>
+            <p className="text-2xl font-semibold text-text-primary">--</p>
           </div>
           <div className="rounded-2xl bg-background px-4 py-3">
             <p className="text-xs uppercase tracking-wide text-text-secondary">Partidas hoy</p>
-            <p className="text-2xl font-semibold text-text-primary">22</p>
+            <p className="text-2xl font-semibold text-text-primary">--</p>
           </div>
           <div className="rounded-2xl bg-background px-4 py-3">
             <p className="text-xs uppercase tracking-wide text-text-secondary">Duplicados pendientes</p>
-            <p className="text-2xl font-semibold text-text-primary">3</p>
+            <p className="text-2xl font-semibold text-text-primary">--</p>
           </div>
         </div>
       </section>

--- a/frontend/src/utils/firebase.ts
+++ b/frontend/src/utils/firebase.ts
@@ -1,0 +1,17 @@
+import { initializeApp } from 'firebase/app'
+import { getAuth } from 'firebase/auth'
+import { getFirestore } from 'firebase/firestore'
+
+const firebaseConfig = {
+  apiKey: 'AIzaSyDL-p8kwxB4vn3rO0DUL-eBFFsAmGZ-MpY',
+  authDomain: 'clbsk26.firebaseapp.com',
+  projectId: 'clbsk26',
+  storageBucket: 'clbsk26.firebasestorage.app',
+  messagingSenderId: '314239716156',
+  appId: '1:314239716156:web:e142bcb20e760cb1fd2c39',
+}
+
+const app = initializeApp(firebaseConfig)
+
+export const auth = getAuth(app)
+export const db = getFirestore(app)


### PR DESCRIPTION
## Summary
- add Firebase initialization helpers and an AuthProvider to share session, profile, and whitelist data across the app
- replace the access onboarding flow with real Firebase Auth + Firestore whitelist validation and profile persistence
- refresh the profile page to read and update user details and preferences stored in Firestore

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4616259d8832c95f18b78e80ae745